### PR TITLE
GeoInterface compat via parameterizing location type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,6 @@ JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 
 [compat]
 EcologicalNetworks = "0.4, 0.5"
-GeoInterface = "0.5"
 HTTP = "0.8, 0.9"
 JSON = "0.21"
 julia = "1.5"

--- a/src/response_format.jl
+++ b/src/response_format.jl
@@ -1,17 +1,17 @@
 """
     format_mangal_coordinates(d::Dict{T,Any}) where {T <: AbstractString}
 
-Returns a set of coordinates in a `GeoInterface` object, which can be a `Point`
-or a `Polygon`.
+Returns a set of coordinates in a `GeoInterface` object, which can be a `PointTrait`
+or a `PolygonTrait`.
 """
 function format_mangal_coordinates(d::Dict{T,Any}) where {T <: AbstractString}
-    point_type = d["geom"]["type"] == "Point" ? Point : Polygon
-    if point_type == Polygon
+    point_type = d["geom"]["type"] == "Point" ? PointTrait : PolygonTrait
+    if point_type == PolygonTrait
         coords = [float.(x) for x in first(d["geom"]["coordinates"])]
-        point_coordinates = point_type(coords)
+        point_coordinates = coords
     else
         coords = float.(d["geom"]["coordinates"])
-        point_coordinates = point_type(coords...)
+        point_coordinates = coords
     end
     return point_coordinates
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -68,7 +68,7 @@ than its owner.
 
 `date` (`DateTime`): date and time at which the network was sampled.
 
-`position` (`AbstractGeometry`): the location at which the network was sampled.
+`position` (`AbstractGeometryTrait`): the location at which the network was sampled.
 This can be any sort of geospatial construct, most notably points *or* polygons.
 
 `complete` (`Bool`): indicates whether the network was sampled completely, or is
@@ -84,12 +84,12 @@ actual authorship.
 
 `description` (`AbstractString`): a free-form description of the network.
 """
-struct MangalNetwork
+struct MangalNetwork{T}
     id::Int64
     public::Bool
     name::AbstractString
     date::Union{DateTime,Missing}
-    position::Union{AbstractGeometry,Missing}
+    position::T
     created::DateTime
     updated::DateTime
     user::Union{Int64,Missing}
@@ -138,13 +138,13 @@ end
 """
 Interaction
 """
-struct MangalInteraction
+struct MangalInteraction{T}
     id::Int64
     network::MangalNetwork
     from::MangalNode
     to::MangalNode
     date::Union{DateTime,Missing}
-    position::Union{AbstractGeometry,Missing}
+    position::T
     directed::Bool
     interaction::Symbol
     method::Union{AbstractString,Missing}

--- a/test/networks.jl
+++ b/test/networks.jl
@@ -9,7 +9,7 @@ module MangalTestNetwork
     @test typeof(nN1) <: Vector{MangalNode}
 
     # Datasets with no arguments
-    @test typeof(networks()) <: Vector{MangalNetwork}
+    @test typeof(networks()) <: Vector{MangalNetwork} 
 
     # Networks by id
     @test typeof(network(19)) <: MangalNetwork


### PR DESCRIPTION
cheap solution to #26. there may be a better way to do this, but in practice GI.jl doesn't use constructors for Points anymore so it might make sense to limit the position type to be a union of `Missing` and `T<:Vector{V} where V<:Real`.


This is blocking some work on the bumblebee project so I'd like to get even a hotfix merged soon